### PR TITLE
Fix pager to work even if url parameter does not have offset

### DIFF
--- a/flexibleSearch.js
+++ b/flexibleSearch.js
@@ -752,6 +752,10 @@
                         offset = "offset=" + offset;
                         var url = location.href.split("?");
                         var query = url[1].replace(/offset=[0-9]+/, offset);
+                        if(query.indexOf('offset=') < 0){
+                            query += '&' + offset;
+                        }
+                        query = query.replace(/&offset=0/, '');
                         location.href = url[0] + "?" + query;
                     })
                     .on("click", "a.fs-turn-page-link", function (e) {


### PR DESCRIPTION
URL パラメータに Offset がない場合でも、ページャが動作するよう調整してみました。
1ページ目のリンクのみ、「&offset=0」自体を除去するようにしてあります。